### PR TITLE
Add unit and component tests (Parts 2-3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.16.5",
         "@types/react": "^18.3.23",
         "@types/react-dom": "^18.3.7",
@@ -3052,6 +3053,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.16.5",
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",

--- a/src/components/__tests__/VideoPane.test.tsx
+++ b/src/components/__tests__/VideoPane.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@/test/mocks/livekit';
+import VideoPane from '../VideoPane';
+
+// Wrap in a simple provider-free render since VideoPane doesn't use context
+function renderVideoPane(props: React.ComponentProps<typeof VideoPane>) {
+  return render(<VideoPane {...props} />);
+}
+
+describe('VideoPane', () => {
+  it('renders Placeholder when participantIdentity is undefined', () => {
+    renderVideoPane({ label: 'Host', sublabel: 'Stream' });
+    expect(screen.getByText('Host')).toBeInTheDocument();
+    expect(screen.getByText('Stream')).toBeInTheDocument();
+    // No video track should be rendered
+    expect(screen.queryByTestId(/video-track/)).not.toBeInTheDocument();
+  });
+
+  it('renders LiveVideoPane when participantIdentity is provided', () => {
+    renderVideoPane({
+      label: 'Host',
+      participantIdentity: 'host@test.com',
+    });
+    // LiveVideoPane is rendered — useTracks returns [] so it falls back
+    // to connecting placeholder, but the component branch is LiveVideoPane
+    expect(screen.getByText('Host')).toBeInTheDocument();
+  });
+
+  it('Placeholder shows "Start Call" for facilitator self-pane when idle + not live', () => {
+    renderVideoPane({
+      label: 'Facilitator',
+      callState: 'idle',
+      isSelf: true,
+      selfRole: 'facilitator',
+      sessionStatus: 'scheduled',
+      onStartCall: () => {},
+    });
+    expect(screen.getByText('Start Call')).toBeInTheDocument();
+  });
+
+  it('Placeholder shows "Join Call" for facilitator self-pane when idle + live', () => {
+    renderVideoPane({
+      label: 'Facilitator',
+      callState: 'idle',
+      isSelf: true,
+      selfRole: 'facilitator',
+      sessionStatus: 'live',
+      onJoinCall: () => {},
+    });
+    expect(screen.getByText('Join Call')).toBeInTheDocument();
+  });
+
+  it('Placeholder shows "Join Call" for startup self-pane when live', () => {
+    renderVideoPane({
+      label: 'AlphaTech',
+      callState: 'idle',
+      isSelf: true,
+      selfRole: 'startup',
+      sessionStatus: 'live',
+      onJoinCall: () => {},
+    });
+    expect(screen.getByText('Join Call')).toBeInTheDocument();
+  });
+
+  it('Placeholder shows "Waiting for host..." for startup self-pane when not live', () => {
+    renderVideoPane({
+      label: 'AlphaTech',
+      callState: 'idle',
+      isSelf: true,
+      selfRole: 'startup',
+      sessionStatus: 'scheduled',
+      onJoinCall: () => {},
+    });
+    expect(screen.getByText('Waiting for host...')).toBeInTheDocument();
+  });
+
+  it('Placeholder shows spinner when callState is "connecting"', () => {
+    renderVideoPane({
+      label: 'Host',
+      callState: 'connecting',
+    });
+    // The Loader2 spinner has the animate-spin class
+    const spinner = document.querySelector('.animate-spin');
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it('"Live" badge appears when isActive is true', () => {
+    renderVideoPane({
+      label: 'AlphaTech',
+      isActive: true,
+    });
+    expect(screen.getByText('Live')).toBeInTheDocument();
+  });
+
+  it('label and sublabel render correctly', () => {
+    renderVideoPane({
+      label: 'Test Label',
+      sublabel: 'Test Sublabel',
+    });
+    expect(screen.getByText('Test Label')).toBeInTheDocument();
+    expect(screen.getByText('Test Sublabel')).toBeInTheDocument();
+  });
+});

--- a/src/hooks/__tests__/buildStages.test.ts
+++ b/src/hooks/__tests__/buildStages.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { buildStages } from '../useSessionStages';
+
+const makeStartup = (email: string, name: string | null, order: number) => ({
+  email,
+  display_name: name,
+  presentation_order: order,
+});
+
+describe('buildStages', () => {
+  it('empty startup list → [Intro, Outro] (2 stages)', () => {
+    const stages = buildStages([]);
+    expect(stages).toHaveLength(2);
+    expect(stages[0].type).toBe('intro');
+    expect(stages[1].type).toBe('outro');
+  });
+
+  it('1 startup → [Intro, Presentation, Q&A, Outro] (4 stages)', () => {
+    const stages = buildStages([makeStartup('a@test.com', 'Alpha', 1)]);
+    expect(stages).toHaveLength(4);
+    expect(stages.map(s => s.type)).toEqual(['intro', 'presentation', 'qa', 'outro']);
+  });
+
+  it('3 startups → 8 stages (intro + 3×(pres+qa) + outro)', () => {
+    const startups = [
+      makeStartup('a@test.com', 'Alpha', 1),
+      makeStartup('b@test.com', 'Beta', 2),
+      makeStartup('c@test.com', 'Gamma', 3),
+    ];
+    const stages = buildStages(startups);
+    expect(stages).toHaveLength(8);
+    expect(stages.map(s => s.type)).toEqual([
+      'intro',
+      'presentation', 'qa',
+      'presentation', 'qa',
+      'presentation', 'qa',
+      'outro',
+    ]);
+  });
+
+  it('each presentation stage has correct startupIndex', () => {
+    const startups = [
+      makeStartup('a@test.com', 'Alpha', 1),
+      makeStartup('b@test.com', 'Beta', 2),
+    ];
+    const stages = buildStages(startups);
+    const presentations = stages.filter(s => s.type === 'presentation');
+    expect(presentations[0].startupIndex).toBe(0);
+    expect(presentations[1].startupIndex).toBe(1);
+  });
+
+  it('each Q&A stage has same startupIndex as preceding presentation', () => {
+    const startups = [
+      makeStartup('a@test.com', 'Alpha', 1),
+      makeStartup('b@test.com', 'Beta', 2),
+    ];
+    const stages = buildStages(startups);
+    for (let i = 0; i < stages.length; i++) {
+      if (stages[i].type === 'qa') {
+        expect(stages[i].startupIndex).toBe(stages[i - 1].startupIndex);
+      }
+    }
+  });
+
+  it('intro and outro have no startupIndex (undefined)', () => {
+    const stages = buildStages([makeStartup('a@test.com', 'Alpha', 1)]);
+    const intro = stages.find(s => s.type === 'intro')!;
+    const outro = stages.find(s => s.type === 'outro')!;
+    expect(intro.startupIndex).toBeUndefined();
+    expect(outro.startupIndex).toBeUndefined();
+  });
+
+  it('stage labels include startup display_name', () => {
+    const stages = buildStages([makeStartup('a@test.com', 'AlphaTech', 1)]);
+    const pres = stages.find(s => s.type === 'presentation')!;
+    const qa = stages.find(s => s.type === 'qa')!;
+    expect(pres.label).toContain('AlphaTech');
+    expect(qa.label).toContain('AlphaTech');
+  });
+
+  it('falls back to email when display_name is null', () => {
+    const stages = buildStages([makeStartup('founder@startup.io', null, 1)]);
+    const pres = stages.find(s => s.type === 'presentation')!;
+    expect(pres.label).toContain('founder@startup.io');
+  });
+
+  it('durations: intro=300s, presentation=300s, qa=180s, outro=300s', () => {
+    const stages = buildStages([makeStartup('a@test.com', 'Alpha', 1)]);
+    const byType = (t: string) => stages.find(s => s.type === t)!;
+    expect(byType('intro').durationSeconds).toBe(300);
+    expect(byType('presentation').durationSeconds).toBe(300);
+    expect(byType('qa').durationSeconds).toBe(180);
+    expect(byType('outro').durationSeconds).toBe(300);
+  });
+});

--- a/src/hooks/__tests__/useSessionStages.test.ts
+++ b/src/hooks/__tests__/useSessionStages.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSessionStages } from '../useSessionStages';
+
+const startups = [
+  { email: 'a@test.com', display_name: 'Alpha', presentation_order: 1 },
+  { email: 'b@test.com', display_name: 'Beta', presentation_order: 2 },
+];
+
+describe('useSessionStages', () => {
+  it('starts at stage 0, paused', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    expect(result.current.currentStageIndex).toBe(0);
+    expect(result.current.isPaused).toBe(true);
+  });
+
+  it('next() advances currentStageIndex by 1', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    act(() => result.current.next());
+    expect(result.current.currentStageIndex).toBe(1);
+  });
+
+  it('prev() decrements currentStageIndex by 1', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    act(() => result.current.goToStage(2));
+    act(() => result.current.prev());
+    expect(result.current.currentStageIndex).toBe(1);
+  });
+
+  it('next() is no-op at last stage', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    const lastIndex = result.current.stages.length - 1;
+    act(() => result.current.goToStage(lastIndex));
+    act(() => result.current.next());
+    expect(result.current.currentStageIndex).toBe(lastIndex);
+  });
+
+  it('prev() is no-op at stage 0', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    act(() => result.current.prev());
+    expect(result.current.currentStageIndex).toBe(0);
+  });
+
+  it('goToStage(n) jumps to stage n and resets remainingSeconds', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    act(() => result.current.goToStage(3));
+    expect(result.current.currentStageIndex).toBe(3);
+    expect(result.current.remainingSeconds).toBe(result.current.stages[3].durationSeconds);
+  });
+
+  it('togglePause() flips isPaused', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    expect(result.current.isPaused).toBe(true);
+    act(() => result.current.togglePause());
+    expect(result.current.isPaused).toBe(false);
+    act(() => result.current.togglePause());
+    expect(result.current.isPaused).toBe(true);
+  });
+
+  it('activeStartupIndex matches currentStage.startupIndex', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    // Stage 1 is Alpha Presentation (startupIndex 0)
+    act(() => result.current.goToStage(1));
+    expect(result.current.activeStartupIndex).toBe(0);
+    // Stage 3 is Beta Presentation (startupIndex 1)
+    act(() => result.current.goToStage(3));
+    expect(result.current.activeStartupIndex).toBe(1);
+  });
+
+  it('activeStartupIndex is undefined during intro/outro', () => {
+    const { result } = renderHook(() => useSessionStages(startups));
+    // Stage 0 is Intro
+    expect(result.current.activeStartupIndex).toBeUndefined();
+    // Last stage is Outro
+    const lastIndex = result.current.stages.length - 1;
+    act(() => result.current.goToStage(lastIndex));
+    expect(result.current.activeStartupIndex).toBeUndefined();
+  });
+});

--- a/src/hooks/useSessionStages.ts
+++ b/src/hooks/useSessionStages.ts
@@ -27,7 +27,7 @@ interface UseSessionStagesReturn {
   activeStartupIndex: number | undefined;
 }
 
-function buildStages(startups: Startup[]): Stage[] {
+export function buildStages(startups: Startup[]): Stage[] {
   const stages: Stage[] = [];
 
   stages.push({

--- a/src/pages/__tests__/Login.test.tsx
+++ b/src/pages/__tests__/Login.test.tsx
@@ -4,29 +4,26 @@ import { BrowserRouter } from 'react-router-dom';
 import { SessionProvider } from '@/lib/sessionContext';
 import Login from '../Login';
 
-const mockSelect = vi.fn();
-const mockUpdate = vi.fn();
-const mockInsert = vi.fn();
+const testSession = {
+  id: 'session-1',
+  name: 'Test Session',
+  start_time: new Date(Date.now() - 60000).toISOString(),
+  end_time: new Date(Date.now() + 3600000).toISOString(),
+};
 
-let sessionCallCount = 0;
+// Tracks the mock for participant lookup so individual tests can customize it
+let participantResult: any = { data: null, error: null };
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
     from: vi.fn((table: string) => {
       if (table === 'sessions') {
-        sessionCallCount++;
-        const isFirstCall = sessionCallCount % 2 === 1;
         return {
           select: vi.fn().mockReturnValue({
-            lte: vi.fn().mockReturnValue({
-              gte: vi.fn().mockReturnValue({
-                eq: vi.fn().mockResolvedValue({
-                  data: isFirstCall ? [{
-                    id: 'session-1',
-                    name: 'Test Session',
-                    start_time: new Date(Date.now() - 60000).toISOString(),
-                    end_time: new Date(Date.now() + 3600000).toISOString(),
-                  }] : [],
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({
+                  data: [testSession],
                 }),
               }),
             }),
@@ -34,12 +31,45 @@ vi.mock('@/integrations/supabase/client', () => ({
         };
       }
       if (table === 'session_participants') {
-        return { select: mockSelect, update: mockUpdate };
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockImplementation(() =>
+                    Promise.resolve(participantResult)
+                  ),
+                }),
+              }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        };
       }
       if (table === 'session_logs') {
-        return { insert: mockInsert };
+        return {
+          insert: vi.fn().mockResolvedValue({ error: null }),
+        };
       }
-      return { select: vi.fn() };
+      if (table === 'app_settings') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { value: 'production' },
+                error: null,
+              }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+        }),
+      };
     }),
   },
 }));
@@ -60,43 +90,23 @@ function renderLogin() {
   );
 }
 
-function setupFacilitatorMock(passwordHash: string) {
-  mockSelect.mockReturnValue({
-    eq: vi.fn().mockReturnValue({
-      eq: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          maybeSingle: vi.fn().mockResolvedValue({
-            data: {
-              id: 'p-1',
-              email: 'admin@test.com',
-              role: 'facilitator',
-              display_name: 'Admin',
-              password_hash: passwordHash,
-              is_logged_in: false,
-            },
-            error: null,
-          }),
-        }),
-      }),
-    }),
-  });
+function setParticipantMock(participant: any) {
+  participantResult = { data: participant, error: null };
 }
 
 async function enterEmailAndClickRole(roleName: string) {
   renderLogin();
   await waitFor(() => expect(screen.getByText(roleName)).toBeInTheDocument());
-  fireEvent.change(screen.getByPlaceholderText('you@company.com'), { target: { value: 'admin@test.com' } });
+  fireEvent.change(screen.getByPlaceholderText('you@company.com'), {
+    target: { value: 'admin@test.com' },
+  });
   fireEvent.click(screen.getByText(roleName));
 }
 
 describe('Login Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    sessionCallCount = 0;
-    mockInsert.mockResolvedValue({ error: null });
-    mockUpdate.mockReturnValue({
-      eq: vi.fn().mockResolvedValue({ error: null }),
-    });
+    participantResult = { data: null, error: null };
   });
 
   it('renders role selection buttons with "Join session as..." label', async () => {
@@ -117,33 +127,75 @@ describe('Login Page', () => {
   });
 
   it('shows password step for facilitator role', async () => {
-    setupFacilitatorMock('secret123');
+    setParticipantMock({
+      id: 'p-1',
+      email: 'admin@test.com',
+      role: 'facilitator',
+      display_name: 'Admin',
+      password_hash: 'secret123',
+      is_logged_in: false,
+    });
     await enterEmailAndClickRole('Facilitator');
-    await waitFor(() => expect(screen.getByPlaceholderText('Enter your password')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('Enter your password')).toBeInTheDocument()
+    );
   });
 
   it('rejects incorrect facilitator password', async () => {
-    setupFacilitatorMock('correct_password');
+    setParticipantMock({
+      id: 'p-1',
+      email: 'admin@test.com',
+      role: 'facilitator',
+      display_name: 'Admin',
+      password_hash: 'correct_password',
+      is_logged_in: false,
+    });
     await enterEmailAndClickRole('Facilitator');
-    await waitFor(() => expect(screen.getByPlaceholderText('Enter your password')).toBeInTheDocument());
-    fireEvent.change(screen.getByPlaceholderText('Enter your password'), { target: { value: 'wrong' } });
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('Enter your password')).toBeInTheDocument()
+    );
+    fireEvent.change(screen.getByPlaceholderText('Enter your password'), {
+      target: { value: 'wrong' },
+    });
     fireEvent.click(screen.getByText('Continue'));
     await waitFor(() => expect(mockNavigate).not.toHaveBeenCalled());
   });
 
   it('accepts correct facilitator password and navigates to session', async () => {
-    setupFacilitatorMock('demo123');
+    setParticipantMock({
+      id: 'p-1',
+      email: 'admin@test.com',
+      role: 'facilitator',
+      display_name: 'Admin',
+      password_hash: 'demo123',
+      is_logged_in: false,
+    });
     await enterEmailAndClickRole('Facilitator');
-    await waitFor(() => expect(screen.getByPlaceholderText('Enter your password')).toBeInTheDocument());
-    fireEvent.change(screen.getByPlaceholderText('Enter your password'), { target: { value: 'demo123' } });
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('Enter your password')).toBeInTheDocument()
+    );
+    fireEvent.change(screen.getByPlaceholderText('Enter your password'), {
+      target: { value: 'demo123' },
+    });
     fireEvent.click(screen.getByText('Continue'));
-    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/session/session-1'));
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith('/session/session-1')
+    );
   });
 
   it('toggles password visibility with eye icon', async () => {
-    setupFacilitatorMock('demo123');
+    setParticipantMock({
+      id: 'p-1',
+      email: 'admin@test.com',
+      role: 'facilitator',
+      display_name: 'Admin',
+      password_hash: 'demo123',
+      is_logged_in: false,
+    });
     await enterEmailAndClickRole('Facilitator');
-    await waitFor(() => expect(screen.getByPlaceholderText('Enter your password')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText('Enter your password')).toBeInTheDocument()
+    );
 
     const passwordInput = screen.getByPlaceholderText('Enter your password');
     expect(passwordInput).toHaveAttribute('type', 'password');

--- a/src/pages/__tests__/Session.test.tsx
+++ b/src/pages/__tests__/Session.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import '@/test/mocks/livekit';
+
+// --- Supabase mock ---
+const mockChannelOn = vi.fn().mockReturnThis();
+const mockChannelSubscribe = vi.fn().mockReturnThis();
+const mockChannel = {
+  on: mockChannelOn,
+  subscribe: mockChannelSubscribe,
+};
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn((table: string) => {
+      if (table === 'sessions') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: {
+                  id: 'session-1',
+                  name: 'Test Session',
+                  status: 'live',
+                  start_time: new Date().toISOString(),
+                  end_time: new Date(Date.now() + 3600000).toISOString(),
+                },
+                error: null,
+              }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        };
+      }
+      if (table === 'session_participants') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn((_col: string, _val: string) => ({
+              eq: vi.fn((_col2: string, val2: string) => {
+                if (val2 === 'startup') {
+                  return {
+                    order: vi.fn().mockResolvedValue({
+                      data: [
+                        { email: 'startup-a@test.com', display_name: 'AlphaTech', presentation_order: 1 },
+                        { email: 'startup-b@test.com', display_name: 'BetaCorp', presentation_order: 2 },
+                      ],
+                      error: null,
+                    }),
+                  };
+                }
+                // facilitator query — no .order(), resolves directly
+                return Promise.resolve({
+                  data: [
+                    { email: 'facilitator@test.com', display_name: 'Test Facilitator' },
+                  ],
+                  error: null,
+                });
+              }),
+            })),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'investments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }
+      if (table === 'session_logs') {
+        return {
+          insert: vi.fn().mockResolvedValue({ error: null }),
+        };
+      }
+      // Default fallback — support .select().eq().order() chains
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      };
+    }),
+    channel: vi.fn(() => mockChannel),
+    removeChannel: vi.fn(),
+  },
+}));
+
+// --- Mock sessionContext to inject user synchronously ---
+const mockLogout = vi.fn();
+let mockUser: any = null;
+
+vi.mock('@/lib/sessionContext', () => ({
+  useSessionUser: vi.fn(() => ({
+    user: mockUser,
+    setUser: vi.fn(),
+    logout: mockLogout,
+  })),
+  SessionProvider: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+}));
+
+// --- LiveKit token mock ---
+vi.mock('@/hooks/useLiveKitToken', () => ({
+  useLiveKitToken: vi.fn(() => ({
+    token: null,
+    ws_url: null,
+    room: null,
+    error: null,
+    loading: false,
+    fetchToken: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn(),
+  })),
+}));
+
+// --- useDemoMode mock ---
+vi.mock('@/hooks/useDemoMode', () => ({
+  useDemoMode: vi.fn(() => ({ isDemoMode: false })),
+}));
+
+// --- Livekit styles mock ---
+vi.mock('@livekit/components-styles', () => ({}));
+
+import SessionPage from '../Session';
+
+function renderSession() {
+  return render(
+    <MemoryRouter initialEntries={['/session/session-1']}>
+      <Routes>
+        <Route path="/session/:id" element={<SessionPage />} />
+        <Route path="/login" element={<div>Login Page</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('Session — facilitator view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = {
+      email: 'facilitator@test.com',
+      role: 'facilitator',
+      displayName: 'Test Facilitator',
+      sessionId: 'session-1',
+    };
+  });
+
+  it('left pane renders facilitator VideoPane', async () => {
+    renderSession();
+    await waitFor(() => {
+      expect(screen.getByText('Test Facilitator')).toBeInTheDocument();
+    });
+  });
+
+  it('center pane renders VideoPane for current startup', async () => {
+    renderSession();
+    await waitFor(() => {
+      // AlphaTech appears in both center pane and funding meter "Now Presenting"
+      expect(screen.getAllByText('AlphaTech').length).toBeGreaterThanOrEqual(1);
+    });
+    // Verify the "Startup Presentation" sublabel in the center pane
+    expect(screen.getByText('Startup Presentation')).toBeInTheDocument();
+  });
+
+  it('stage controls visible: Previous, Play/Pause, Next', async () => {
+    renderSession();
+    await waitFor(() => {
+      expect(screen.getByText('Previous')).toBeInTheDocument();
+      expect(screen.getByText('Play')).toBeInTheDocument();
+      expect(screen.getByText('Next')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Session — investor view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = {
+      email: 'investor-1@test.com',
+      role: 'investor',
+      displayName: 'Investor One',
+      sessionId: 'session-1',
+    };
+  });
+
+  it('stage controls NOT visible', async () => {
+    renderSession();
+    await waitFor(() => {
+      expect(screen.getByText('Investor One (investor)')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Previous')).not.toBeInTheDocument();
+    expect(screen.queryByText('Next')).not.toBeInTheDocument();
+  });
+
+  it('"Invest" button visible', async () => {
+    renderSession();
+    await waitFor(() => {
+      expect(screen.getByText('Invest')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Session — startup view', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = {
+      email: 'startup-a@test.com',
+      role: 'startup',
+      displayName: 'AlphaTech',
+      sessionId: 'session-1',
+    };
+  });
+
+  it('stage controls NOT visible', async () => {
+    renderSession();
+    await waitFor(() => {
+      expect(screen.getByText('AlphaTech (startup)')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Previous')).not.toBeInTheDocument();
+    expect(screen.queryByText('Next')).not.toBeInTheDocument();
+  });
+});

--- a/src/test/mocks/livekit.ts
+++ b/src/test/mocks/livekit.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+import { vi } from 'vitest';
+
+vi.mock('@livekit/components-react', () => ({
+  LiveKitRoom: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children),
+  useParticipants: vi.fn(() => []),
+  useTracks: vi.fn(() => []),
+  VideoTrack: ({ trackRef }: any) =>
+    React.createElement('div', {
+      'data-testid': `video-track-${trackRef?.participant?.identity ?? 'unknown'}`,
+    }),
+  useLocalParticipant: vi.fn(() => ({ localParticipant: null })),
+  RoomAudioRenderer: () => null,
+}));
+
+vi.mock('livekit-client', () => ({
+  Track: { Source: { Camera: 'camera', Microphone: 'microphone' } },
+}));

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,5 +1,8 @@
 import "@testing-library/jest-dom";
 
+// jsdom doesn't implement scrollIntoView
+Element.prototype.scrollIntoView = () => {};
+
 Object.defineProperty(window, "matchMedia", {
   writable: true,
   value: (query: string) => ({


### PR DESCRIPTION
## Summary
- **Part 2**: Unit tests for `buildStages` (9 tests) and `useSessionStages` hook (9 tests) — pure logic, no browser, no network
- **Part 3**: Component tests for `VideoPane` (9 tests) and `Session` page (6 tests) — mocked Supabase + LiveKit, role-based rendering
- **Fix**: Rewrote `Login.test.tsx` mock to match current Supabase query chains — was broken before this PR
- **Infra**: Added canonical LiveKit mock (`src/test/mocks/livekit.ts`), jsdom `scrollIntoView` polyfill, `@testing-library/user-event`

**40/40 tests passing**, 0 failures.

## Test plan
- [x] `npm test` — all 40 tests pass
- [x] No regressions to existing example test or Login tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)