### PR TITLE
Fix prod session creation (RLS) + timezone-aware scheduling, pickers & emails

### DIFF
--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -1,0 +1,78 @@
+import { Clock } from 'lucide-react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+/** Format a 24-hour "HH:mm" value as a friendly 12-hour label, e.g. "9:00 AM". */
+function to12Hour(value: string): string {
+  const [hStr, mStr] = value.split(':');
+  const h = Number(hStr);
+  const m = mStr ?? '00';
+  if (Number.isNaN(h)) return value;
+  const period = h < 12 ? 'AM' : 'PM';
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+  return `${h12}:${m} ${period}`;
+}
+
+/** Build "HH:mm" options every `stepMinutes` across a 24-hour day. */
+function buildOptions(stepMinutes: number): { value: string; label: string }[] {
+  const opts: { value: string; label: string }[] = [];
+  for (let h = 0; h < 24; h++) {
+    for (let m = 0; m < 60; m += stepMinutes) {
+      const value = `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+      opts.push({ value, label: to12Hour(value) });
+    }
+  }
+  return opts;
+}
+
+interface TimePickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Granularity of the options in minutes. Defaults to 15. */
+  stepMinutes?: number;
+  id?: string;
+  className?: string;
+}
+
+/**
+ * A dropdown time picker built on shadcn Select. Unlike a native <input
+ * type="time">, it is unambiguously a clickable picker (clock icon + chevron)
+ * and the open list scrolls with visible up/down scroll buttons. The bound
+ * value stays in 24-hour "HH:mm" form so existing date parsing is unchanged.
+ */
+export default function TimePicker({
+  value,
+  onChange,
+  stepMinutes = 15,
+  id,
+  className,
+}: TimePickerProps) {
+  const options = buildOptions(stepMinutes);
+  // If the current value doesn't fall on a step boundary (e.g. seeded data),
+  // surface it as an extra option so the trigger still shows a label.
+  const hasValue = !value || options.some((o) => o.value === value);
+  const allOptions = hasValue
+    ? options
+    : [{ value, label: to12Hour(value) }, ...options];
+
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger id={id} className={className ?? 'mt-1'} aria-label="Select time">
+        <Clock className="mr-2 h-4 w-4 shrink-0 opacity-60" />
+        <SelectValue placeholder="Select time" />
+      </SelectTrigger>
+      <SelectContent>
+        {allOptions.map((o) => (
+          <SelectItem key={o.value} value={o.value}>
+            {o.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -35,6 +35,7 @@ interface TimePickerProps {
   onChange: (value: string) => void;
   /** Granularity of the options in minutes. Defaults to 15. */
   stepMinutes?: number;
+  disabled?: boolean;
   id?: string;
   className?: string;
 }
@@ -49,6 +50,7 @@ export default function TimePicker({
   value,
   onChange,
   stepMinutes = 15,
+  disabled = false,
   id,
   className,
 }: TimePickerProps) {
@@ -61,7 +63,7 @@ export default function TimePicker({
     : [{ value, label: to12Hour(value) }, ...options];
 
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select value={value} onValueChange={onChange} disabled={disabled}>
       <SelectTrigger id={id} className={className ?? 'mt-1'} aria-label="Select time">
         <Clock className="mr-2 h-4 w-4 shrink-0 opacity-60" />
         <SelectValue placeholder="Select time" />

--- a/src/components/TimezonePicker.tsx
+++ b/src/components/TimezonePicker.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useState } from 'react';
+import { Check, ChevronsUpDown, Globe } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+/**
+ * Fallback list used only if the browser lacks Intl.supportedValuesOf
+ * (older browsers). Modern browsers return the full IANA database instead.
+ */
+const FALLBACK_TIMEZONES = [
+  'UTC',
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Anchorage',
+  'America/Phoenix',
+  'America/Toronto',
+  'America/Mexico_City',
+  'America/Sao_Paulo',
+  'Europe/London',
+  'Europe/Dublin',
+  'Europe/Paris',
+  'Europe/Berlin',
+  'Europe/Madrid',
+  'Europe/Rome',
+  'Europe/Amsterdam',
+  'Europe/Athens',
+  'Europe/Moscow',
+  'Africa/Cairo',
+  'Africa/Johannesburg',
+  'Asia/Dubai',
+  'Asia/Kolkata',
+  'Asia/Bangkok',
+  'Asia/Singapore',
+  'Asia/Hong_Kong',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Asia/Seoul',
+  'Australia/Sydney',
+  'Australia/Perth',
+  'Pacific/Auckland',
+  'Pacific/Honolulu',
+];
+
+/** Full IANA timezone list when available, otherwise the curated fallback. */
+function listTimezones(): string[] {
+  try {
+    const supported = (Intl as unknown as {
+      supportedValuesOf?: (key: string) => string[];
+    }).supportedValuesOf;
+    if (typeof supported === 'function') {
+      const zones = supported('timeZone');
+      if (zones?.length) return zones;
+    }
+  } catch {
+    /* fall through to fallback */
+  }
+  return FALLBACK_TIMEZONES;
+}
+
+interface TimezonePickerProps {
+  value: string;
+  onChange: (value: string) => void;
+  id?: string;
+  className?: string;
+}
+
+/**
+ * Searchable timezone combobox (shadcn Popover + Command). The user can only
+ * pick a valid IANA timezone from the list — no free-text guessing at the
+ * format — and can type to filter, e.g. "york" → America/New_York.
+ */
+export default function TimezonePicker({
+  value,
+  onChange,
+  id,
+  className,
+}: TimezonePickerProps) {
+  const [open, setOpen] = useState(false);
+  const timezones = useMemo(listTimezones, []);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn('w-full justify-between font-normal', className ?? 'mt-1')}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <Globe className="h-4 w-4 shrink-0 opacity-60" />
+            <span className="truncate">{value || 'Select timezone'}</span>
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder="Search timezone..." />
+          <CommandList>
+            <CommandEmpty>No timezone found.</CommandEmpty>
+            <CommandGroup>
+              {timezones.map((tz) => (
+                <CommandItem
+                  key={tz}
+                  value={tz}
+                  onSelect={() => {
+                    onChange(tz);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      'mr-2 h-4 w-4',
+                      value === tz ? 'opacity-100' : 'opacity-0',
+                    )}
+                  />
+                  {tz}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/lib/__tests__/timezone.test.ts
+++ b/src/lib/__tests__/timezone.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  zonedWallTimeToUtcISO,
+  formatDateInTimeZone,
+  formatTimeInTimeZone,
+} from '../timezone';
+
+describe('zonedWallTimeToUtcISO', () => {
+  it('converts a summer (EDT, UTC-4) wall time to UTC', () => {
+    expect(zonedWallTimeToUtcISO('2026-06-18', '09:00', 'America/New_York')).toBe(
+      '2026-06-18T13:00:00.000Z',
+    );
+  });
+
+  it('converts a winter (EST, UTC-5) wall time to UTC', () => {
+    expect(zonedWallTimeToUtcISO('2026-01-15', '09:00', 'America/New_York')).toBe(
+      '2026-01-15T14:00:00.000Z',
+    );
+  });
+
+  it('is a no-op for UTC', () => {
+    expect(zonedWallTimeToUtcISO('2026-06-18', '09:00', 'UTC')).toBe(
+      '2026-06-18T09:00:00.000Z',
+    );
+  });
+
+  it('handles a half-hour offset zone (IST, UTC+5:30)', () => {
+    expect(zonedWallTimeToUtcISO('2026-06-18', '09:00', 'Asia/Kolkata')).toBe(
+      '2026-06-18T03:30:00.000Z',
+    );
+  });
+
+  it('handles a zone ahead of UTC that crosses the date line backward', () => {
+    // 01:00 in Tokyo (UTC+9) is 16:00 the previous day in UTC.
+    expect(zonedWallTimeToUtcISO('2026-06-18', '01:00', 'Asia/Tokyo')).toBe(
+      '2026-06-17T16:00:00.000Z',
+    );
+  });
+
+  it('throws on malformed input', () => {
+    expect(() => zonedWallTimeToUtcISO('not-a-date', '09:00', 'UTC')).toThrow();
+  });
+});
+
+describe('formatTimeInTimeZone', () => {
+  it('renders a UTC instant as local time in the target zone', () => {
+    // 13:00 UTC is 09:00 in New York (EDT).
+    expect(formatTimeInTimeZone('2026-06-18T13:00:00.000Z', 'America/New_York')).toBe(
+      '9:00 AM',
+    );
+  });
+
+  it('appends the zone abbreviation when requested', () => {
+    expect(
+      formatTimeInTimeZone('2026-06-18T15:00:00.000Z', 'America/New_York', true),
+    ).toBe('11:00 AM EDT');
+  });
+
+  it('renders the same instant differently in another zone', () => {
+    expect(formatTimeInTimeZone('2026-06-18T13:00:00.000Z', 'America/Los_Angeles')).toBe(
+      '6:00 AM',
+    );
+  });
+});
+
+describe('formatDateInTimeZone', () => {
+  it('uses the target zone to decide the calendar date', () => {
+    // 02:00 UTC on the 18th is still the 17th in Los Angeles (UTC-7 in summer).
+    expect(formatDateInTimeZone('2026-06-18T02:00:00.000Z', 'America/Los_Angeles')).toBe(
+      'Wednesday, June 17, 2026',
+    );
+  });
+});

--- a/src/lib/logError.ts
+++ b/src/lib/logError.ts
@@ -1,0 +1,64 @@
+import { toast } from 'sonner';
+
+/**
+ * Normalized shape pulled out of a Supabase / PostgREST error (or any thrown
+ * value). Supabase errors carry `message`, plus optional Postgres `code`,
+ * `details`, and `hint` fields that are extremely useful for debugging but are
+ * usually thrown away by generic "something went wrong" handlers.
+ */
+export interface NormalizedError {
+  message: string;
+  code?: string;
+  details?: string;
+  hint?: string;
+}
+
+/** Extract the useful fields from a Supabase error, Error, or arbitrary value. */
+export function normalizeError(error: unknown): NormalizedError {
+  if (!error) return { message: 'Unknown error' };
+  if (typeof error === 'string') return { message: error };
+  const e = error as Record<string, unknown>;
+  return {
+    message: (e.message as string) ?? String(error),
+    code: e.code as string | undefined,
+    details: e.details as string | undefined,
+    hint: e.hint as string | undefined,
+  };
+}
+
+/**
+ * Human-readable one-liner that keeps the Postgres code and hint when present,
+ * e.g. `new row violates row-level security policy for table "sessions" [42501]`.
+ * Suitable for a toast description.
+ */
+export function describeError(error: unknown): string {
+  const { message, code, hint } = normalizeError(error);
+  let out = message || 'Unknown error';
+  if (code) out += ` [${code}]`;
+  if (hint) out += ` — ${hint}`;
+  return out;
+}
+
+/**
+ * Central place to surface a failure so it is easy to see and fix:
+ *   1. Logs full structured context to the console (visible in prod via
+ *      browser devtools — including code/details/hint and the raw error).
+ *   2. Shows the user a toast whose title is the action that failed and whose
+ *      description is the real underlying error (not a generic message).
+ *
+ * Pass `{ toast: false }` to log only. Returns the human-readable description.
+ */
+export function reportError(
+  context: string,
+  error: unknown,
+  opts: { toast?: boolean } = {},
+): string {
+  const normalized = normalizeError(error);
+  // Single structured console line so production issues are obvious in devtools.
+  console.error(`[FundFlow] ${context}:`, { ...normalized, raw: error });
+  const description = describeError(error);
+  if (opts.toast !== false) {
+    toast.error(context, { description });
+  }
+  return description;
+}

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,92 @@
+/**
+ * Timezone helpers for scheduling.
+ *
+ * A session is scheduled as a *wall-clock* time in a specific IANA time zone
+ * (e.g. "9:00 AM in America/New_York"). We must store that as an absolute UTC
+ * instant, and later render it back in the session's zone for display/emails.
+ * These helpers use the built-in `Intl` APIs (full IANA + DST data in modern
+ * browsers and Deno/Node), so no extra dependency is required.
+ */
+
+/**
+ * Offset of `timeZone` at the given UTC instant, in minutes, defined so that:
+ *   wallClock = utcInstant + offset
+ * e.g. America/New_York in summer (EDT, UTC-4) returns -240.
+ */
+function tzOffsetMinutes(timeZone: string, utcDate: Date): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const map: Record<string, number> = {};
+  for (const part of dtf.formatToParts(utcDate)) {
+    if (part.type !== 'literal') map[part.type] = Number(part.value);
+  }
+  // Some engines format midnight as hour "24"; normalize to 0.
+  const hour = map.hour % 24;
+  const asIfUTC = Date.UTC(map.year, map.month - 1, map.day, hour, map.minute, map.second);
+  return (asIfUTC - utcDate.getTime()) / 60000;
+}
+
+/**
+ * Interpret a wall-clock `date` + `time` as being in `timeZone`, and return the
+ * corresponding UTC instant as an ISO string.
+ *
+ * @param date  Calendar date as "YYYY-MM-DD" (e.g. from <input type="date">).
+ * @param time  Wall-clock time as "HH:mm" (24-hour).
+ * @param timeZone  IANA zone id, e.g. "America/New_York".
+ *
+ * @example
+ *   zonedWallTimeToUtcISO('2026-06-18', '09:00', 'America/New_York')
+ *   // => '2026-06-18T13:00:00.000Z'  (09:00 EDT == 13:00 UTC)
+ */
+export function zonedWallTimeToUtcISO(date: string, time: string, timeZone: string): string {
+  const [y, mo, d] = date.split('-').map(Number);
+  const [h, mi] = time.split(':').map(Number);
+  if ([y, mo, d, h, mi].some((n) => Number.isNaN(n))) {
+    throw new RangeError(`Invalid date/time/zone: "${date}" "${time}" "${timeZone}"`);
+  }
+  // Treat the wall time as if it were already UTC, then correct by the zone's
+  // offset at that instant. Accurate except for wall times that fall inside a
+  // DST transition gap/overlap (sessions are not normally scheduled there).
+  const utcGuess = Date.UTC(y, mo - 1, d, h, mi, 0);
+  const offset = tzOffsetMinutes(timeZone, new Date(utcGuess));
+  return new Date(utcGuess - offset * 60000).toISOString();
+}
+
+/**
+ * Format a UTC timestamp as a calendar date in `timeZone`,
+ * e.g. "Thursday, June 18, 2026".
+ */
+export function formatDateInTimeZone(utc: string | Date, timeZone: string): string {
+  return new Date(utc).toLocaleDateString('en-US', {
+    timeZone,
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+}
+
+/**
+ * Format a UTC timestamp as a time-of-day in `timeZone`, e.g. "9:00 AM".
+ * When `withZoneName` is true, appends the zone abbreviation, e.g. "9:00 AM EDT".
+ */
+export function formatTimeInTimeZone(
+  utc: string | Date,
+  timeZone: string,
+  withZoneName = false,
+): string {
+  return new Date(utc).toLocaleTimeString('en-US', {
+    timeZone,
+    hour: 'numeric',
+    minute: '2-digit',
+    ...(withZoneName ? { timeZoneName: 'short' } : {}),
+  });
+}

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -20,6 +20,11 @@ import DemoModeBanner from '@/components/DemoModeBanner';
 import TimePicker from '@/components/TimePicker';
 import TimezonePicker from '@/components/TimezonePicker';
 import { reportError } from '@/lib/logError';
+import {
+  zonedWallTimeToUtcISO,
+  formatDateInTimeZone,
+  formatTimeInTimeZone,
+} from '@/lib/timezone';
 
 interface SessionRow {
   id: string;
@@ -81,13 +86,9 @@ export default function Admin() {
   const [newDate, setNewDate] = useState('');
   const [newStartTime, setNewStartTime] = useState('09:00');
   const [newEndTime, setNewEndTime] = useState('11:00');
-  const [newTimezone, setNewTimezone] = useState(() => {
-    try {
-      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York';
-    } catch {
-      return 'America/New_York';
-    }
-  });
+  // Start empty so the facilitator must consciously pick the session's timezone
+  // before choosing times — the times are interpreted in this zone.
+  const [newTimezone, setNewTimezone] = useState('');
 
   // Add participant form
   const [addEmail, setAddEmail] = useState('');
@@ -356,15 +357,21 @@ export default function Admin() {
   }, [isAuthenticated]);
 
   const createSession = async () => {
+    if (!newTimezone) {
+      toast.error('Please pick a timezone first');
+      return;
+    }
     if (!newName || !newDate || !newStartTime || !newEndTime) {
       toast.error('Please fill all fields');
       return;
     }
+    // Interpret the chosen wall-clock times as being in the session's timezone,
+    // then store the absolute UTC instants.
     let startISO: string;
     let endISO: string;
     try {
-      startISO = new Date(`${newDate}T${newStartTime}`).toISOString();
-      endISO = new Date(`${newDate}T${newEndTime}`).toISOString();
+      startISO = zonedWallTimeToUtcISO(newDate, newStartTime, newTimezone);
+      endISO = zonedWallTimeToUtcISO(newDate, newEndTime, newTimezone);
     } catch (err) {
       reportError('Invalid date or time', err);
       return;
@@ -516,11 +523,13 @@ export default function Admin() {
       const welcomeMsg = role === 'facilitator' ? welcomeFacilitator
         : role === 'startup' ? welcomeStartup : welcomeInvestor;
 
-      const sessionDate = new Date(selectedSession.start_time).toLocaleDateString('en-US', {
-        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'
-      });
-      const startT = new Date(selectedSession.start_time).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
-      const endT = new Date(selectedSession.end_time).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', timeZoneName: 'short' });
+      // Render the date/time in the session's own timezone so attendees see the
+      // correct local time and zone (e.g. "9:00 AM — 11:00 AM EDT"), regardless
+      // of the facilitator's browser timezone.
+      const tz = selectedSession.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+      const sessionDate = formatDateInTimeZone(selectedSession.start_time, tz);
+      const startT = formatTimeInTimeZone(selectedSession.start_time, tz);
+      const endT = formatTimeInTimeZone(selectedSession.end_time, tz, true);
       const sessionTime = `${startT} — ${endT}`;
 
       const loginUrl = `${window.location.origin}/login?session=${selectedSession.id}&email=${encodeURIComponent(email)}&role=${role}${role === 'startup' ? '&edit=true' : ''}`;
@@ -820,19 +829,22 @@ export default function Admin() {
                   <Label>Date</Label>
                   <Input type="date" value={newDate} onChange={e => setNewDate(e.target.value)} className="mt-1" />
                 </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="start-time">Start Time</Label>
-                    <TimePicker id="start-time" value={newStartTime} onChange={setNewStartTime} />
-                  </div>
-                  <div>
-                    <Label htmlFor="end-time">End Time</Label>
-                    <TimePicker id="end-time" value={newEndTime} onChange={setNewEndTime} />
-                  </div>
-                </div>
                 <div>
                   <Label htmlFor="timezone">Timezone</Label>
                   <TimezonePicker id="timezone" value={newTimezone} onChange={setNewTimezone} />
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Pick the timezone first — start and end times are set in this zone.
+                  </p>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="start-time">Start Time</Label>
+                    <TimePicker id="start-time" value={newStartTime} onChange={setNewStartTime} disabled={!newTimezone} />
+                  </div>
+                  <div>
+                    <Label htmlFor="end-time">End Time</Label>
+                    <TimePicker id="end-time" value={newEndTime} onChange={setNewEndTime} disabled={!newTimezone} />
+                  </div>
                 </div>
                 <Button onClick={createSession} className="bg-accent text-accent-foreground hover:bg-accent/90">
                   <Plus className="w-4 h-4 mr-1" /> Create Session
@@ -857,7 +869,7 @@ export default function Admin() {
                       <div>
                         <h3 className="font-semibold">{s.name}</h3>
                         <p className="text-sm text-muted-foreground">
-                          {new Date(s.start_time).toLocaleString()} — {new Date(s.end_time).toLocaleTimeString()}
+                          {formatDateInTimeZone(s.start_time, s.timezone || 'UTC')}, {formatTimeInTimeZone(s.start_time, s.timezone || 'UTC')} — {formatTimeInTimeZone(s.end_time, s.timezone || 'UTC', true)}
                         </p>
                       </div>
                       <div className="flex items-center gap-2">
@@ -900,7 +912,7 @@ export default function Admin() {
                   </CardHeader>
                   <CardContent>
                     <p className="text-sm text-muted-foreground">
-                      {new Date(selectedSession.start_time).toLocaleString()} — {new Date(selectedSession.end_time).toLocaleTimeString()}
+                      {formatDateInTimeZone(selectedSession.start_time, selectedSession.timezone || 'UTC')}, {formatTimeInTimeZone(selectedSession.start_time, selectedSession.timezone || 'UTC')} — {formatTimeInTimeZone(selectedSession.end_time, selectedSession.timezone || 'UTC', true)}
                     </p>
                     <p className="text-sm text-muted-foreground">Timezone: {selectedSession.timezone}</p>
                   </CardContent>

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -17,6 +17,9 @@ import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import { motion } from 'framer-motion';
 import DemoModeBanner from '@/components/DemoModeBanner';
+import TimePicker from '@/components/TimePicker';
+import TimezonePicker from '@/components/TimezonePicker';
+import { reportError } from '@/lib/logError';
 
 interface SessionRow {
   id: string;
@@ -78,7 +81,13 @@ export default function Admin() {
   const [newDate, setNewDate] = useState('');
   const [newStartTime, setNewStartTime] = useState('09:00');
   const [newEndTime, setNewEndTime] = useState('11:00');
-  const [newTimezone, setNewTimezone] = useState('America/New_York');
+  const [newTimezone, setNewTimezone] = useState(() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York';
+    } catch {
+      return 'America/New_York';
+    }
+  });
 
   // Add participant form
   const [addEmail, setAddEmail] = useState('');
@@ -351,15 +360,27 @@ export default function Admin() {
       toast.error('Please fill all fields');
       return;
     }
-    const startISO = new Date(`${newDate}T${newStartTime}`).toISOString();
-    const endISO = new Date(`${newDate}T${newEndTime}`).toISOString();
+    let startISO: string;
+    let endISO: string;
+    try {
+      startISO = new Date(`${newDate}T${newStartTime}`).toISOString();
+      endISO = new Date(`${newDate}T${newEndTime}`).toISOString();
+    } catch (err) {
+      reportError('Invalid date or time', err);
+      return;
+    }
 
-    const { data: overlapping } = await supabase
+    const { data: overlapping, error: overlapError } = await supabase
       .from('sessions')
       .select('id, name')
       .lt('start_time', endISO)
       .gt('end_time', startISO)
       .neq('status', 'completed');
+
+    if (overlapError) {
+      reportError('Could not check for scheduling conflicts', overlapError);
+      return;
+    }
 
     if (overlapping && overlapping.length > 0) {
       toast.error(`Time conflict with "${overlapping[0].name}". Only one session can be active at a time.`);
@@ -374,7 +395,7 @@ export default function Admin() {
       status: 'scheduled' as const,
     });
     if (error) {
-      toast.error('Failed to create session');
+      reportError('Failed to create session', error);
       return;
     }
     toast.success('Session created!');
@@ -386,14 +407,22 @@ export default function Admin() {
   };
 
   const deleteSession = async (id: string) => {
-    await supabase.from('sessions').delete().eq('id', id);
+    const { error } = await supabase.from('sessions').delete().eq('id', id);
+    if (error) {
+      reportError('Failed to delete session', error);
+      return;
+    }
     toast.success('Session deleted');
     setSelectedSession(null);
     fetchSessions();
   };
 
   const updateSessionStatus = async (id: string, status: "draft" | "scheduled" | "live" | "completed") => {
-    await supabase.from('sessions').update({ status }).eq('id', id);
+    const { error } = await supabase.from('sessions').update({ status }).eq('id', id);
+    if (error) {
+      reportError(`Failed to set session to ${status}`, error);
+      return;
+    }
     toast.success(`Session ${status}`);
     fetchSessions();
   };
@@ -793,17 +822,17 @@ export default function Admin() {
                 </div>
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <Label>Start Time</Label>
-                    <Input type="time" value={newStartTime} onChange={e => setNewStartTime(e.target.value)} className="mt-1" />
+                    <Label htmlFor="start-time">Start Time</Label>
+                    <TimePicker id="start-time" value={newStartTime} onChange={setNewStartTime} />
                   </div>
                   <div>
-                    <Label>End Time</Label>
-                    <Input type="time" value={newEndTime} onChange={e => setNewEndTime(e.target.value)} className="mt-1" />
+                    <Label htmlFor="end-time">End Time</Label>
+                    <TimePicker id="end-time" value={newEndTime} onChange={setNewEndTime} />
                   </div>
                 </div>
                 <div>
-                  <Label>Timezone</Label>
-                  <Input value={newTimezone} onChange={e => setNewTimezone(e.target.value)} placeholder="America/New_York" className="mt-1" />
+                  <Label htmlFor="timezone">Timezone</Label>
+                  <TimezonePicker id="timezone" value={newTimezone} onChange={setNewTimezone} />
                 </div>
                 <Button onClick={createSession} className="bg-accent text-accent-foreground hover:bg-accent/90">
                   <Plus className="w-4 h-4 mr-1" /> Create Session

--- a/supabase/migrations/20260618000000_fix_sessions_insert_delete_rls.sql
+++ b/supabase/migrations/20260618000000_fix_sessions_insert_delete_rls.sql
@@ -1,0 +1,24 @@
+-- Fix: the sessions INSERT and DELETE policies were restricted to the
+-- 'authenticated' role, but this app uses the anon publishable key (it has no
+-- Supabase Auth). Every request therefore arrives as the 'anon' role, so the
+-- Admin "Create Session" insert was rejected with:
+--   new row violates row-level security policy for table "sessions"  (code 42501)
+--
+-- This is the root cause of session creation failing in production. The chosen
+-- timezone was never relevant. Demo mode was unaffected because demo sessions are
+-- seeded server-side by the seed-demo-data Edge Function using the service-role
+-- key, which bypasses RLS entirely.
+--
+-- This mirrors 20260331000002_fix_sessions_rls.sql, which already fixed the exact
+-- same problem for UPDATE. Facilitator access is gated in the application layer
+-- (facilitator password), consistent with the rest of this project's permissive
+-- RLS model (see "Participants insertable by all", "App settings insertable by
+-- all", etc.).
+
+DROP POLICY IF EXISTS "Sessions are insertable by authenticated" ON public.sessions;
+CREATE POLICY "Sessions insertable by all"
+  ON public.sessions FOR INSERT WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Sessions are deletable by authenticated" ON public.sessions;
+CREATE POLICY "Sessions deletable by all"
+  ON public.sessions FOR DELETE USING (true);


### PR DESCRIPTION
## Summary

Three connected fixes for the **Create Session** flow:
1. 🔴 Production session creation was failing (RLS) — fixed.
2. Confusing time / timezone inputs — replaced with proper pickers.
3. Session times were not timezone-aware, and invitation emails didn't reflect the session's timezone — fixed end-to-end.

---

## 1. Production failure: sessions INSERT/DELETE RLS

Session creation failed for **any** timezone because of **Row Level Security**, not the timezone value:

- The `sessions` table's `INSERT`/`DELETE` policies were `TO authenticated`.
- This app has **no Supabase Auth** (anon publishable key), so requests arrive as `anon` and the insert is rejected: `new row violates row-level security policy for table "sessions"` (code `42501`).
- Demo mode worked only because `seed-demo-data` inserts with the **service-role key** (bypasses RLS).
- Migration `20260331000002` already fixed this for `UPDATE` but left `INSERT`/`DELETE` broken.

**Fix:** migration `20260618000000_fix_sessions_insert_delete_rls.sql` replaces the authenticated-only `INSERT`/`DELETE` policies with permissive ones (matching the existing `UPDATE` fix and the app's app-layer-gated model).

> ⚠️ **Deploy step:** this migration must be applied to the production Supabase project (`supabase db push` / dashboard) for the fix to take effect.

## 2. Error instrumentation

New `src/lib/logError.ts` → `reportError(context, error)` logs a structured console line (`message`/`code`/`details`/`hint`/raw) and shows the **real** error in the toast instead of a generic message. Applied to `createSession`, `deleteSession`, `updateSessionStatus`, plus a guard on date parsing and the previously-ignored overlap query. The RLS failure would have been obvious immediately with this in place.

## 3. Pickers

- **TimePicker** (`src/components/TimePicker.tsx`): dropdown `Select` (clock icon + visible scroll buttons) replacing the native `<input type="time">`. Value stays `"HH:mm"`.
- **TimezonePicker** (`src/components/TimezonePicker.tsx`): searchable combobox over the IANA list (`Intl.supportedValuesOf` with fallback). No more free-text guessing; type to filter (e.g. `york` → `America/New_York`).

## 4. Timezone-aware scheduling + emails

- **Storage:** `createSession` now interprets start/end as wall-clock times **in the selected timezone** and stores the correct UTC instant, via new DST-aware `src/lib/timezone.ts` (`zonedWallTimeToUtcISO`). Previously they were interpreted in the facilitator's *browser* zone.
- **UX:** Timezone picker now comes **first**, and the time pickers are **disabled until a timezone is chosen** ("pick the timezone first"). Timezone no longer auto-defaults — a conscious choice is required.
- **Email:** `sendWelcomeEmail` formats `sessionDate`/`sessionTime` in the session's **stored timezone**, so invitations show the correct local time + zone abbreviation (e.g. `9:00 AM — 11:00 AM EDT`) regardless of who sends them. The `session-invitation` template already rendered these fields — the caller was formatting them in the wrong zone, which is the piece that had slipped.
- **Admin list/detail** session times now also render in the session's timezone, consistent with the displayed `Timezone:` label.

`src/lib/timezone.ts` is covered by unit tests (EDT/EST/UTC/IST, date-line crossing, zone-abbreviation formatting).

## Testing
- `npm run build` ✓
- `npm run test` ✓ (63 passed, incl. 10 new timezone tests)
- `npm run lint` ✓ (no new errors; 5 pre-existing `no-explicit-any` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)