### PR TITLE
Fix supabase db reset + add offline demo-mode dev workflow

### DIFF
--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -357,6 +357,60 @@ Requires Colima running and steps 1-3 completed first.
 
 ---
 
+## Demo mode (offline dev/test)
+
+The steps above seed **test** data (`facilitator@test.com`). To instead run the
+app in **demo mode** — which lists `[DEMO]` sessions and lets facilitators log in
+*without a password* — use the offline path below. It needs only local Supabase
+(no LiveKit, no internet).
+
+### Two gotchas that bite offline
+
+1. **`DOCKER_HOST` / Colima socket.** Step 1 has you point `DOCKER_HOST` at
+   `/var/run/docker.sock`, which only exists if you created the `sudo` symlink.
+   If you skipped that, the Supabase CLI can't find Docker. Either create the
+   symlink (step 1) **or** point `DOCKER_HOST` straight at Colima's own socket
+   for the session:
+
+   ```
+   mac% export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"
+   ```
+
+2. **Edge Functions can't seed demo data offline.** The Admin UI's "Seed Demo
+   Data" button calls the `seed-demo-data` Edge Function, which imports from
+   `esm.sh`. The Deno edge runtime inside Colima can't reach the network, so it
+   fails (HTTP 503 "name resolution failed"). Seed via SQL instead (below).
+   The same limitation applies to `livekit-token` and `participant-login` — but
+   demo mode doesn't need them: video degrades gracefully, and demo-mode
+   facilitator login bypasses the password step entirely.
+
+### Steps
+
+```
+mac% export DOCKER_HOST="unix://$HOME/.colima/default/docker.sock"   # if no symlink
+mac% supabase start                                                  # or: supabase db reset
+mac% # enable demo mode + load 3 [DEMO] sessions and their participants:
+mac% psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" \
+       -f tests/fixtures/seed-demo.sql
+mac% npx vite --mode test --port 8080                                # loads .env.test (local)
+```
+
+Open [http://localhost:8080](http://localhost:8080). You should see the
+**⚠ DEMO MODE ⚠** banner and "[DEMO] Demo Day Alpha". Log in:
+
+| Email                  | Role        | Password           |
+| ---------------------- | ----------- | ------------------ |
+| `facilitator@demo.com` | facilitator | *(none — bypassed)* |
+| `admin@demo.com`       | facilitator | *(none — bypassed)* |
+| `acme@demo.com`        | startup     | —                  |
+| `alice@investor.com`   | investor    | —                  |
+
+Re-running `seed-demo.sql` is safe — it clears existing `[DEMO]` data first. To
+return to production/cloud mode, set `app_settings.mode` back to `production`
+(or anything other than `demo`).
+
+---
+
 ## Shutting down
 
 ```

--- a/supabase/migrations/20260403012822_7de0cea2-e17c-4bc5-b598-e06eefb58d4d.sql
+++ b/supabase/migrations/20260403012822_7de0cea2-e17c-4bc5-b598-e06eefb58d4d.sql
@@ -1,1 +1,18 @@
-ALTER PUBLICATION supabase_realtime ADD TABLE public.session_participants;
+-- Idempotent guard: public.session_participants is already added to the
+-- supabase_realtime publication by 20260331000001_add_participants_realtime.sql.
+-- On a clean `supabase db reset` this duplicate ADD fails with
+-- "relation ... is already member of publication" (SQLSTATE 42710), which
+-- aborts the whole reset. Postgres has no "ADD TABLE IF NOT EXISTS" for
+-- publications, so guard it explicitly. (In environments where this migration
+-- was already applied, it is recorded by version and will not re-run.)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'session_participants'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.session_participants;
+  END IF;
+END $$;

--- a/tests/fixtures/seed-demo.sql
+++ b/tests/fixtures/seed-demo.sql
@@ -1,0 +1,61 @@
+-- Demo-mode seed data — offline equivalent of the `seed-demo-data` Edge Function.
+--
+-- The Admin UI's "Seed Demo Data" button calls that Edge Function, but the local
+-- Deno edge runtime fetches its imports from esm.sh and cannot reach the network
+-- inside Colima, so it fails offline. This SQL produces the same end state and
+-- runs fully offline via psql (which connects as the `postgres` superuser and
+-- therefore bypasses RLS). Demo facilitator passwords are stored in plaintext
+-- here and hashed on insert by the hash_participant_password trigger.
+--
+-- Usage:
+--   psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -f tests/fixtures/seed-demo.sql
+--
+-- Safe to re-run: it clears existing [DEMO] data first.
+
+-- 1. Turn demo mode on.
+INSERT INTO app_settings (key, value) VALUES ('mode', 'demo')
+  ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value;
+
+-- 2. Clear any previous demo data (children first to satisfy FKs).
+DELETE FROM chat_messages        WHERE session_id IN (SELECT id FROM sessions WHERE name LIKE '[DEMO]%');
+DELETE FROM investments          WHERE session_id IN (SELECT id FROM sessions WHERE name LIKE '[DEMO]%');
+DELETE FROM session_logs         WHERE session_id IN (SELECT id FROM sessions WHERE name LIKE '[DEMO]%');
+DELETE FROM session_participants WHERE session_id IN (SELECT id FROM sessions WHERE name LIKE '[DEMO]%');
+DELETE FROM sessions             WHERE name LIKE '[DEMO]%';
+
+-- 3. Sessions (times relative to now, mirroring the Edge Function).
+INSERT INTO sessions (id, name, start_time, end_time, status, timezone) VALUES
+  ('a0000000-0000-0000-0000-000000000001', '[DEMO] Demo Day Alpha', now() - interval '1 hour',  now() + interval '2 hours',  'live',      'America/New_York'),
+  ('b0000000-0000-0000-0000-000000000002', '[DEMO] Demo Day Beta',  now() - interval '25 hours', now() - interval '22 hours', 'completed', 'America/New_York'),
+  ('c0000000-0000-0000-0000-000000000003', '[DEMO] Demo Day Gamma', now() - interval '49 hours', now() - interval '46 hours', 'completed', 'America/New_York');
+
+-- 4. Participants.
+INSERT INTO session_participants
+  (session_id, email, display_name, role, password_hash, presentation_order, website_link, dd_room_link, funding_goal) VALUES
+  -- Alpha (live)
+  ('a0000000-0000-0000-0000-000000000001', 'facilitator@demo.com', 'Facilitator 1', 'facilitator', 'demo123', NULL, NULL, NULL, NULL),
+  ('a0000000-0000-0000-0000-000000000001', 'admin@demo.com',       'Facilitator 2', 'facilitator', 'demo123', NULL, NULL, NULL, NULL),
+  ('a0000000-0000-0000-0000-000000000001', 'acme@demo.com',  'AcmeTech',  'startup', NULL, 1, 'https://acmetech.io', 'https://drive.google.com/acme',  2000000),
+  ('a0000000-0000-0000-0000-000000000001', 'nova@demo.com',  'NovaPay',   'startup', NULL, 2, 'https://novapay.com', 'https://drive.google.com/nova',  5000000),
+  ('a0000000-0000-0000-0000-000000000001', 'green@demo.com', 'GreenGrid', 'startup', NULL, 3, 'https://greengrid.co','https://drive.google.com/green', 3000000),
+  ('a0000000-0000-0000-0000-000000000001', 'alice@investor.com', 'Alice Chen',    'investor', NULL, NULL, NULL, NULL, NULL),
+  ('a0000000-0000-0000-0000-000000000001', 'bob@investor.com',   'Bob Martinez',  'investor', NULL, NULL, NULL, NULL, NULL),
+  ('a0000000-0000-0000-0000-000000000001', 'carol@investor.com', 'Carol Nguyen',  'investor', NULL, NULL, NULL, NULL, NULL),
+  ('a0000000-0000-0000-0000-000000000001', 'dave@investor.com',  'Dave Wilson',   'investor', NULL, NULL, NULL, NULL, NULL),
+  -- Beta (completed yesterday)
+  ('b0000000-0000-0000-0000-000000000002', 'facilitator@demo.com', 'Facilitator 1', 'facilitator', 'demo123', NULL, NULL, NULL, NULL),
+  ('b0000000-0000-0000-0000-000000000002', 'admin@demo.com',       'Facilitator 2', 'facilitator', 'demo123', NULL, NULL, NULL, NULL),
+  ('b0000000-0000-0000-0000-000000000002', 'cloud@demo.com', 'CloudSync', 'startup', NULL, 1, 'https://cloudsync.dev','https://drive.google.com/cloudsync', 1500000),
+  ('b0000000-0000-0000-0000-000000000002', 'forge@demo.com', 'DataForge', 'startup', NULL, 2, 'https://dataforge.ai', 'https://drive.google.com/dataforge', 4000000),
+  ('b0000000-0000-0000-0000-000000000002', 'pixel@demo.com', 'PixelAI',   'startup', NULL, 3, 'https://pixelai.co',   'https://drive.google.com/pixelai',   2500000),
+  ('b0000000-0000-0000-0000-000000000002', 'eve@investor.com',   'Eve Park',  'investor', NULL, NULL, NULL, NULL, NULL),
+  ('b0000000-0000-0000-0000-000000000002', 'frank@investor.com', 'Frank Liu', 'investor', NULL, NULL, NULL, NULL, NULL),
+  -- Gamma (completed 2 days ago)
+  ('c0000000-0000-0000-0000-000000000003', 'facilitator@demo.com', 'Facilitator 1', 'facilitator', 'demo123', NULL, NULL, NULL, NULL),
+  ('c0000000-0000-0000-0000-000000000003', 'admin@demo.com',       'Facilitator 2', 'facilitator', 'demo123', NULL, NULL, NULL, NULL),
+  ('c0000000-0000-0000-0000-000000000003', 'solar@demo.com', 'SolarWave', 'startup', NULL, 1, 'https://solarwave.energy','https://drive.google.com/solarwave', 6000000),
+  ('c0000000-0000-0000-0000-000000000003', 'finly@demo.com', 'Finly',     'startup', NULL, 2, 'https://finly.io',        'https://drive.google.com/finly',     1000000),
+  ('c0000000-0000-0000-0000-000000000003', 'mediq@demo.com', 'MediQ',     'startup', NULL, 3, 'https://mediq.health',    'https://drive.google.com/mediq',     8000000),
+  ('c0000000-0000-0000-0000-000000000003', 'ivan@investor.com',  'Ivan Petrov',  'investor', NULL, NULL, NULL, NULL, NULL),
+  ('c0000000-0000-0000-0000-000000000003', 'julia@investor.com', 'Julia Santos', 'investor', NULL, NULL, NULL, NULL, NULL),
+  ('c0000000-0000-0000-0000-000000000003', 'kyle@investor.com',  'Kyle Brown',   'investor', NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
## Summary

Makes the local dev environment actually bootstrap from scratch and adds a documented, offline **demo-mode** workflow. Found while setting up local Supabase for offline dev/test in demo mode.

## 1. `supabase db reset` was broken 🔴

A clean `supabase db reset` aborted partway through:

```
ERROR: relation "session_participants" is already member of publication "supabase_realtime" (SQLSTATE 42710)
At statement: ALTER PUBLICATION supabase_realtime ADD TABLE public.session_participants
```

Migration `20260403012822` repeats an `ALTER PUBLICATION … ADD TABLE session_participants` already performed by `20260331000001`. Postgres has no `ADD TABLE IF NOT EXISTS` for publications, so a from-scratch reset always failed — meaning **no new developer could bring up the stack**. Fixed by guarding the duplicate with a `pg_publication_tables` existence check (idempotent; recorded-by-version so it won't re-run where already applied).

## 2. Offline demo seed (`tests/fixtures/seed-demo.sql`)

The Admin "Seed Demo Data" button calls the `seed-demo-data` Edge Function, which imports from `esm.sh`. The Deno edge runtime inside Colima can't reach the network, so it returns `503 "name resolution failed"` — demo data can't be seeded offline that way. This SQL fixture produces the same end state fully offline via `psql` (superuser → bypasses RLS; facilitator passwords hashed by the existing trigger): enables demo mode + 3 `[DEMO]` sessions and their participants. Safe to re-run.

## 3. `docs/dev_setup.md` — "Demo mode (offline dev/test)"

New section documenting the workflow and the two gotchas that bite offline:
- **`DOCKER_HOST`/Colima socket** — the documented `/var/run/docker.sock` path needs the `sudo` symlink; alternatively point `DOCKER_HOST` at `~/.colima/default/docker.sock`.
- **Edge Functions are unavailable offline** (`seed-demo-data`, `livekit-token`, `participant-login`) — demo mode needs none of them: video degrades gracefully and demo-mode facilitator login bypasses the password step.

## Verification

Verified end-to-end locally: `supabase db reset` now applies all migrations cleanly → seed via SQL → `vite --mode test` → browser login as `facilitator@demo.com` (no password) reaches the live `[DEMO]` session page with **zero console errors**.

> Note: does not touch application code. The unrelated session-RLS/timezone work lives in #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)