### PR TITLE
Realtime investor count + role labels in chat

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -87,6 +87,7 @@ export default function ChatPanel({ sessionId }: { sessionId: string }) {
               <div className="flex items-baseline gap-2">
                 <span className={`text-xs font-semibold ${roleColor(msg.sender_role)}`}>
                   {msg.sender_name || msg.sender_email}
+                  <span className="font-normal text-muted-foreground"> ({msg.sender_role})</span>
                 </span>
                 <span className="text-[10px] text-muted-foreground">
                   {new Date(msg.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -18,7 +18,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { DollarSign, ExternalLink, Loader2, LogOut, PhoneOff, Play, Pause, ChevronLeft, ChevronRight, Monitor, MonitorOff, Video, Settings, Volume2, VolumeOff, Mic, MicOff } from 'lucide-react';
+import { DollarSign, ExternalLink, Loader2, LogOut, PhoneOff, Play, Pause, ChevronLeft, ChevronRight, Monitor, MonitorOff, Video, Settings, Volume2, VolumeOff, Mic, MicOff, Eye } from 'lucide-react';
 import DemoModeBanner from '@/components/DemoModeBanner';
 import { toast } from 'sonner';
 
@@ -49,6 +49,7 @@ export default function SessionPage() {
   const [callState, setCallState] = useState<CallState>('idle');
   const [stageIdentity, setStageIdentity] = useState<string | null>(null);
   const [localMuted, setLocalMuted] = useState(false);
+  const [investorCount, setInvestorCount] = useState(0);
 
   const {
     stages,
@@ -259,9 +260,19 @@ export default function SessionPage() {
         }
       })
       .on('presence', { event: 'sync' }, () => {
+        const state = channel.presenceState();
+
+        // Count investors currently present (across all tracked presences)
+        let investors = 0;
+        for (const presences of Object.values(state)) {
+          for (const p of presences as any[]) {
+            if (p?.role === 'investor') investors++;
+          }
+        }
+        setInvestorCount(investors);
+
         // Late joiner: read facilitator's tracked state on first sync
         if (!isFac && !hasInitialSync.current) {
-          const state = channel.presenceState();
           for (const presences of Object.values(state)) {
             const p = (presences as any[])?.[0];
             if (p?.currentStageIndex !== undefined) {
@@ -274,10 +285,14 @@ export default function SessionPage() {
         }
       })
       .subscribe(async (status) => {
-        if (status === 'SUBSCRIBED' && isFac) {
-          await channel.track({
-            currentStageIndex, isPaused, remainingSeconds, stageIdentity,
-          });
+        if (status === 'SUBSCRIBED') {
+          // Everyone tracks their presence so investors can be counted.
+          // Facilitator additionally tracks stage state for late joiners.
+          await channel.track(
+            isFac
+              ? { role: user?.role, email: user?.email, currentStageIndex, isPaused, remainingSeconds, stageIdentity }
+              : { role: user?.role, email: user?.email }
+          );
         }
       });
 
@@ -666,6 +681,16 @@ export default function SessionPage() {
           )}
         </div>
         <div className="flex items-center gap-2">
+          <span
+            className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground"
+            data-testid="investor-watching-count"
+            title="Investors currently in this session"
+          >
+            <Eye className="w-3.5 h-3.5 text-blue-400" />
+            {investorCount === 1
+              ? 'There is 1 Investor watching this session'
+              : `There are ${investorCount} Investors watching this session`}
+          </span>
           <span className="text-xs text-muted-foreground">{user.displayName} ({user.role})</span>
           <Button variant="ghost" size="sm" onClick={handleLogout}>
             <LogOut className="w-4 h-4" />


### PR DESCRIPTION
## What

Two session-room UX additions:

1. **Realtime investor count** — the session header now shows a live indicator: *"There are N Investors watching this session"* (with a singular *"There is 1 Investor…"* variant). It's driven by Supabase Realtime **presence**: every participant tracks `{role, email}` on the existing `stage-sync-${id}` channel, and the count is recomputed on each presence sync, so it updates as investors join/leave.

2. **Role labels in chat** — each message sender is now labelled with their role, e.g. `Rich (facilitator)`, `Ian (startup)`, `Sam (investor)`.

## Files

- `src/pages/Session.tsx` — presence tracking for all roles, `investorCount` state, header indicator (`Eye` icon).
- `src/components/ChatPanel.tsx` — role appended to sender name.

## Notes

- The count reflects participants actually connected to the session page (not the DB roster), and counts each open tab as one viewer.
- The indicator is currently visible to all roles.
- `tsc --noEmit` passes; remaining eslint `no-explicit-any` hits are pre-existing in the file and the one new cast matches the adjacent presence-handling pattern.